### PR TITLE
Stop including completed builds in later builds

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . $npm_package_productName --prune --asar --all --version=0.29.1"
+    "build": "electron-packager . $npm_package_productName --out=dist --ignore=dist --prune --asar --all --version=0.29.1"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
The current electron-packager command builds into the working directory. When it targets multiple platforms or architectures, each subsequent build *includes all the previous builds*, leading to **exponential increases in build sizes**.

Just building the template app after running the generator **makes a build that is 2GB**. The first build is a mere 100MB.